### PR TITLE
Update doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generated proto and gRPC classes for Google Cloud Platform in PHP
 This repository contains the PHP classes generated from protos contained in
 [Google APIs][].
 
-- [Documentation] (http://googleapis.github.io/proto-client-php/phpdoc)
+- [Documentation](http://googleapis.github.io/gax-php)
 
 [gRPC]: http://grpc.io
 [Google APIs]: https://github.com/googleapis/googleapis/


### PR DESCRIPTION
NOTE: this is intentionally pointing to gax-php, which now has a combined doc site